### PR TITLE
Remove redundant 3‑arg moveTowards

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,12 +71,6 @@ Math.clamp = function(number, min, max) {
     else return number;
 }
 
-Math.moveTowards = function(current, target, amount)
-{
-    if (current<target) return Math.min(current+amount, target);
-    else return Math.max(current-amount, target);
-}
-
 Math.moveTowards = function(current, target, amountUp, amountDown)
 {
     if (current<target) return Math.min(current+amountUp, target);


### PR DESCRIPTION
## Summary
- remove obsolete 3-argument `Math.moveTowards`
- keep existing 4-argument version for all usages

## Testing
- `node test.js` *(ensures no calls to the old 3-argument API)*

------
https://chatgpt.com/codex/tasks/task_e_6844c0a8e0d0832dbc663d70af7e1e3d